### PR TITLE
Added various options to be configurable per SP basis instead of glob…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # Laravel SAML
 
-Laravel-SAML adds SAML support to make a laravel application to both a SAML identity provider (IDP) and a SAML service provider (SP). The package is designed to work with Laravel 5.4.
+Laravel-SAML adds SAML2 support to make a laravel application both a SAML2 identity provider (IdP) and a SAML2 service provider (SP). The package is designed to work with Laravel 5.4 or above.
 
 The package is mostly designed to function according to following guide:
 https://imbringingsyntaxback.com/implementing-a-saml-idp-with-laravel/
 
 To get a better basic understanding for SAML in general, read https://github.com/jch/saml
 
-## Installation
+Supported Features
+* SP initiated login
+* RelayState
 
-### Basic package installation
+## Installation and Configuration
 
-Using ```composer```: 
+Require the package using composer 
 
-``` 
-composer require "kingstarter/laravel-saml":"dev-master"
+``` bash
+   $ composer require "kingstarter/laravel-saml":"dev-master"
 ```
 #### Laravel 5.4
 Add the service provider to ```config/app.php```
@@ -22,50 +24,48 @@ Add the service provider to ```config/app.php```
 ```
     KingStarter\LaravelSaml\LaravelSamlServiceProvider::class,
 ```
-#### Laravel 5.5
+#### Laravel 5.5+
 This package supports Laravel's Package Auto Discovery and should be automatically loaded when required using composer. If the package is not auto discovered run
 
 ```bash
-    php artisan package:discover
+    $ php artisan package:discover
 ```
 #### Configuration
-There is one configuration file to publish and the config/filesystem.php file that needs to be extended. The command
+To change the default configuration, publish the package's config file.
+
+```bash
+   $ php artisan vendor:publish --tag="saml_config"
 ```
-php artisan vendor:publish --tag="saml_config"
-```
 
-will publish the config/saml.php file. 
+This will create a `config/saml.php` file in your app's config folder.
 
-#### SAML SP entries
+Add the following entry to the `config/filesystem.php` file.
 
-Within the saml.php config file the SAML Service Provider array needs to be filled. Subsequently an example from the config/saml.php file:
+```php
+    'disks' => [
 
-```
-'sp' => [        
-    
-    /**
-     * Sample SP entry
-     * The entry is identified by the base64 encoded URL. This example shows a possible entry for
-     * a SimpleSamlPhp service provider running on localhost:
-     * 
-     * Sample URL:         https://localhost/samlsp/module.php/saml/sp/saml2-acs.php/default-sp
-     * Base64 encoded URL: aHR0cHM6Ly9sb2NhbGhvc3Qvc2FtbHNwL21vZHVsZS5waHAvc2FtbC9zcC9zYW1sMi1hY3MucGhwL2RlZmF1bHQtc3A=
-     */
-    'aHR0cHM6Ly9sb2NhbGhvc3Qvc2FtbHNwL21vZHVsZS5waHAvc2FtbC9zcC9zYW1sMi1hY3MucGhwL2RlZmF1bHQtc3A=' => [
-    
-        // The destination is the consuming SAML URL. This might be a SamlAuthController receiving the SAML response.  
-        'destination' => 'https://localhost/samlsp/module.php/saml/sp/saml2-acs.php/default-sp',
-        // Issuer could be anything, mostly it makes sense to pass the metadata URL
-        'issuer' => 'https://localhost',
+        ...
         
-        // OPTIONAL: Use a specific audience restriction value when creating the SAMLRequest object.
-        //           Default value is the assertion consumer service URL (the base64 encoded SP url). 
-        //           This is a bugfix for Nextcloud as SP and can be removed for normal SPs.
-        'audience_restriction' => 'http://localhost',
+        'saml' => [
+            'driver' => 'local',
+            'root' => storage_path().'/saml',
+        ],
+
     ],
-    
-],
 ```
+
+The filesystem requires the following folder `storage/saml/idp` which should be created automatically for you when publishing the config file.
+
+You will need to place the following files with the `storage/saml/idp` folder:
+- cert.pem
+- key.pem
+- metadata.xml - Can be generated at [https://www.samltool.com/idp_metadata.php](https://www.samltool.com/idp_metadata.php)
+
+These filenames can be overridden within the `config/saml.php` file under `idp`
+
+#### Configuring IdP: Adding Service Providers
+
+Each Service Provider (SP) that you want to allow to authenticate with your Identity Service Provider (IdP) must have it's own entry within the Service Provider ('sp') array in your `config/saml.php` file. Each entry's key must equal the base_64 encoded Assertion URL of the Service Provider.   
 
 You can generate the base_64 encoded AssertionURL by using the following artisan command.
  
@@ -76,8 +76,10 @@ You can generate the base_64 encoded AssertionURL by using the following artisan
    Encoded AssertionURL:aHR0cHM6Ly9zcC53ZWJhcHAuY29tL3NhbWwvbG9naW4=
 ```
 
-config/saml.php:
-```
+Use the AssertionURL output by the artisan command as the key for your new SP entry. Following is the minimum configuration required for an SP.
+
+`config/saml.php:`
+```php
 'sp' => [        
     
      ...
@@ -93,36 +95,55 @@ config/saml.php:
         'issuer'      => 'https://sp.webapp.com',
     ],
 ],
+``` 
+
+##### Optional Configuration
+
+There are various optional settings that can be included on a per SP basis to override the IdP's default behaviour. This section details the settings and the default behaviour.
+
+##### Forward Roles
+The global ```forward_roles``` setting can be overridden on a per SP basis by including it within SP's entry within the 'SP' array
+
+| Setting | Description |
+| ------- | ----------- |
+| forward_roles | Boolean value whether to forward roles to the SP |
+
+```php
+            'forward_roles' => true,
 ```
 
-#### FileSystem configuration 
+##### User Identifier / NameID
+The default global nameID used by the IdP is email address. This is the identifier given to the SP as the user's username or user identifier. 
 
-Within ```config/filesystem.php``` following entry needs to be added:
-```
-    'disks' => [
+This can be overridden on a per SP basis by including the following settings within SP's entry within the 'SP' array.
 
-        ...
+| Setting | Description |
+| ------- | ----------- |
+| name_id_format | Can be any of the NAME_ID_ constants listed in ```\LightSaml\SamlConstants::class```<br />Default: 'NAME_ID_FORMAT_EMAIL' |
+| name_id_field | The name of the attribute to retrieve from the User model ('email' would result in $user->email)<br />Default: 'email'
         
-        'saml' => [
-            'driver' => 'local',
-            'root' => storage_path().'/saml',
-        ],
+```php
+            'name_id_format' => 'NAME_ID_FORMAT_EMAIL',
+            'name_id_field' => 'email',
+```
+                  
+##### User Attributes
+By default, the IdP will return the following User Model Attributes to the SP, ```email```, ```name```  
 
-    ],
+This can be overridden on a per SP basis by including an ```attributes``` array within SP's entry within the 'SP' array.
+
+Provide an array where the key is a constant from ```\LightSaml\ClaimTypes::class``` and the value is the attribute to retrieve from the User model ('name' would result in $user->name)
+
+```php
+            'attributes' => [
+                'EMAIL_ADDRESS' => 'email',
+                'COMMON_NAME' => 'name',
+            ],
 ```
 
-The package controllers are using the ```storage/saml``` path for retrieving both certificates and the metadata file. Create first the storage path, then either add or link the certificates. Add also a metadata file for the SAML IDP. For help generating an IDP metadata.xml file, see https://www.samltool.com/idp_metadata.php.
+#### IdP Setup: Authentication
 
-```
-mkdir -p storage/saml/idp
-touch storage/saml/{metadata.xml,cert.pem,key.pem}
-```
-
-Add the contents to the metadata.xml, cert.pem and key.pem files for the IDP. 
-
-### Using the SAML package
-
-To use the SAML package, some files need to be modified. Within your login view, problably ```resources/views/auth/login.blade.php``` add a SAMLRequest field beneath the CSRF field (this is actually a good place for it):
+To use the SAML package as an IdP, some files need to be modified. Within your login view, problably ```resources/views/auth/login.blade.php``` add a SAMLRequest field beneath the CSRF field (this is actually a good place for it):
 ```
     {{-- The hidden CSRF field for secure authentication --}}
     {{ csrf_field() }}
@@ -199,7 +220,7 @@ class RedirectIfAuthenticated
 }
 ```
 
-## SAML Service Providers
+#### Debugging
+If there is an issue, you can enable debugging which will output information to your log file.
 
-To add one or more service providers, go to the ```config/saml.php``` configuration file and scroll down to the 'sp' array. Having the Login-Address of the SAML-SP, add another entry. For reasons of internal interpretation, the URL needs to be Base64 encoded. In case that there are some problems receiving the Base64 string, it is always possible to use the debugger setting the ```saml.debug_saml_request``` flag within the config file. Make sure that the environmental logging variable ```APP_LOG_LEVEL``` is set to debug.
-
+Set ```debug_saml_request``` to true within your `config/saml.php` file. Your environmental variable ```APP_LOG_LEVEL``` must also be set to `debug`.

--- a/src/LaravelSamlServiceProvider.php
+++ b/src/LaravelSamlServiceProvider.php
@@ -48,9 +48,8 @@ class LaravelSamlServiceProvider extends ServiceProvider
             if (!file_exists(storage_path() . "/saml/idp")) {
                 mkdir(storage_path() . "/saml/idp", 0755, true);
             }
+            $this->registerCommands();
         }
-
-        $this->registerCommands();
     }
 
     /**

--- a/src/config/saml.php
+++ b/src/config/saml.php
@@ -94,6 +94,33 @@ return [
             //           Default value is the assertion consumer service URL (the base64 encoded SP url). 
             //           This is a bugfix for Nextcloud as SP and can be removed for normal SPs.
             'audience_restriction' => 'http://localhost/saml/idp/metadata',
+
+            // -----------------------------------------------------------
+            // The following settings are optional and are assigned per SP
+            // -----------------------------------------------------------
+
+            //OPTIONAL: Specify on a SP basis whether to forward roles to the SP
+            'forward_roles' => false,
+
+            //OPTIONAL: Override the default identifying field sent to the SP
+            //          name_id_type -  Can be any of the NAME_ID_ constants listed in \LightSaml\SamlConstants
+            //                          Defaults: 'NAME_ID_FORMAT_EMAIL'
+            //          name_id_field - The name of the attribute to retrieve from the User model ('email' would result in $user->email)
+            //                          Defaults: 'email'
+
+            'name_id_format' => 'NAME_ID_FORMAT_EMAIL',
+            'name_id_field' => 'email',
+
+            //OPTIONAL: Override the default set of user attributes passed to the SP
+            //          Provide an array where the key is a constant from \LightSaml\ClaimTypes
+            //          value is the attribute to retrieve from the User model ('name' would result in $user->name)
+            //          Default: ['EMAIL_ADDRESS' => 'email',
+            //                    'COMMON_NAME' => 'name']
+
+            'attributes' => [
+                'EMAIL_ADDRESS' => 'email',
+                'COMMON_NAME' => 'name',
+            ],
         ],
         
     ],


### PR DESCRIPTION
…ally and added configurable user model attributes to send to SP.

Removed hard coded roles, email and name
Tidied up assertions to own methods for readability
forward_roles now configurable on per SP basis as well as globally. SP config takes priority over global setting
name_id_format and name_id_type now configurable on a per SP basis, defaults to NAME_ID_FORMAT_EMAIL and User Model Email attribute
User model attributes sent to SP now configurable on a per SP basis via attributes array within SP's entry in config. If config not present SP will be sent the user model attribute email and name as default
Updated config/saml.php to show new optional settings
Updated README.md to show new optional settings
Tidied and Updated README.md to hopefully provide better flow of setup instructions